### PR TITLE
Correctly translated UI Theme in French

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -215,7 +215,7 @@
         "badgeGalleryColProgress": "Prochaine amélioration de la colonne (Badges)"
       },
       "uiTheme": {
-        "title": "Thème UI",
+        "title": "Thème d'IU",
         "auto": "AUTO"
       },
       "createParty": {


### PR DESCRIPTION
UI Theme was incorrectly partially translated as "Thème UI" in French, and it is now fixed by using the correct french abbreviation for UI (being **I**nterface **U**tilisateur in French).