### PR TITLE
Handle unsuccessful 2kki API requests

### DIFF
--- a/2kki.js
+++ b/2kki.js
@@ -11,13 +11,16 @@ function send2kkiApiRequest(url, callback) {
     const req = new XMLHttpRequest();
     req.responseType = 'json';
     req.open('GET', url);
+    req.timeout = 10000;
     req.send();
 
-    req.onload = _e => {
+    let onReqEnd = _e => {
       for (let cb of pendingRequests[url])
+        // response is null if request was not successful
         cb(req.response);
       delete pendingRequests[url];
     };
+    req.onloadend = req.ontimeout = onReqEnd;
   }
 }
 
@@ -396,7 +399,7 @@ function getOrQuery2kkiLocationColors(locationName) {
     const callback = response => {
       let errCode = null;
 
-      if (!response?.err_code)
+      if (response?.err_code === '')
         cache2kkiLocationColors(locationName, response.fgColor, response.bgColor);
       else
         errCode = response?.err_code;
@@ -404,7 +407,7 @@ function getOrQuery2kkiLocationColors(locationName) {
       if (errCode)
         console.error({ error: response.error, errCode: errCode });
 
-      resolve([response.fgColor, response.bgColor]);
+      resolve([response?.fgColor, response?.bgColor]);
     };
     send2kkiApiRequest(url, callback);
   });

--- a/2kki.js
+++ b/2kki.js
@@ -399,7 +399,7 @@ function getOrQuery2kkiLocationColors(locationName) {
     const callback = response => {
       let errCode = null;
 
-      if (response?.err_code === '')
+      if (response && !response.err_code)
         cache2kkiLocationColors(locationName, response.fgColor, response.bgColor);
       else
         errCode = response?.err_code;


### PR DESCRIPTION
This is focused on attempting to fix the location cache getting stuck with several "Querying Location" entries, causing permanent-until-reload location data request blocking at [`2kki.js|onLoad2kkiMap:31`](https://github.com/ynoproject/forest-orb/blob/a0f44928fad49dcc24967826220098e5fbdd6fdf/2kki.js#L31). Using the `loadend` event will handle `error` and `abort` events (not that the latter is currently used). Additionally, a timeout of 10 seconds is enforced, in case the server is unavailable or unresponsive for whatever reason.

Callbacks reliant on the response have been checked for compatibility and modified if necessary.
The list checked is:
* [`2kki.js|queryAndSet2kkiLocation:94`](https://github.com/ynoproject/forest-orb/blob/a0f44928fad49dcc24967826220098e5fbdd6fdf/2kki.js#L94)
* [`2kki.js|queryConnected2kkiLocationNames:310`](https://github.com/ynoproject/forest-orb/blob/a0f44928fad49dcc24967826220098e5fbdd6fdf/2kki.js#L310)
* [`2kki.js|queryAndSet2kkiMaps:331`](https://github.com/ynoproject/forest-orb/blob/a0f44928fad49dcc24967826220098e5fbdd6fdf/2kki.js#L331)
* [`2kki.js|getOrQuery2kkiLocationColors:396`](https://github.com/ynoproject/forest-orb/blob/a0f44928fad49dcc24967826220098e5fbdd6fdf/2kki.js#L396)

Unrelated to the purpose of this pull request but still a bug to fix, in `getOrQuery2kkiLocationColors`, the condition `!response?.err_code` would evaluate to `!undefined` -> `true` when the short circuit is used. Because the passing condition is `response.err_code` being `undefined`, the `?.` operator conflicts with the condition. As such, the condition has been changed to `response && !response.err_code`.