### PR TITLE
Always set localized locations to default when fetch is unsuccessful

### DIFF
--- a/play.js
+++ b/play.js
@@ -1377,9 +1377,6 @@ function fetchAndInitLocalizedMapLocations(lang, game) {
 >>>>>>> be6cbea (Always set localized locations to default when fetch fails)
     })
     .then(jsonResponse => {
-      if (!jsonResponse) {
-        return Promise.reject();
-      }
       gameLocalizedLocationUrlRoots[game] = jsonResponse.urlRoot;
       gameLocalizedMapLocations[game] = {};
       const langMapLocations = jsonResponse.mapLocations;

--- a/play.js
+++ b/play.js
@@ -1353,28 +1353,10 @@ function fetchAndInitLocations(lang, game) {
 }
 
 function fetchAndInitLocalizedMapLocations(lang, game) {
-<<<<<<< HEAD
-  return new Promise(resolve => {
-    const fileName = lang === 'en' ? 'config' : lang;
-    fetchNewest(`locations/${game}/${fileName}.json`)
-      .then(response => {
-        if (!response.ok) {
-          gameLocalizedMapLocations[game] = gameMapLocations[game];
-          if (game === gameId) {
-            localizedMapLocations = mapLocations;
-            initLocalizedLocations(game);
-            resolve();
-          } else
-            initLocalizedLocations(game);
-          return null; // Assume map location localizations for this language don't exist
-        }
-        return response.json();
-=======
   const fileName = lang === 'en' ? 'config' : lang;
   return fetchNewest(`locations/${game}/${fileName}.json`)
     .then(response => {
       return response.ok ? response.json() : Promise.reject();
->>>>>>> be6cbea (Always set localized locations to default when fetch fails)
     })
     .then(jsonResponse => {
       gameLocalizedLocationUrlRoots[game] = jsonResponse.urlRoot;

--- a/play.js
+++ b/play.js
@@ -1389,8 +1389,8 @@ function fetchAndInitLocalizedMapLocations(lang, game) {
       if (game === gameId) {
         localizedLocationUrlRoot = locationUrlRoot;
         localizedMapLocations = mapLocations;
-        initLocalizedLocations(game);
       }
+      initLocalizedLocations(game);
     });
 }
 

--- a/play.js
+++ b/play.js
@@ -1402,8 +1402,10 @@ function fetchAndInitLocalizedMapLocations(lang, game) {
       initLocalizedLocations(game);
     })
     .catch(_err => { // Assume map location localizations for this language don't exist
+      gameLocalizedLocationUrlRoots[game] = gameLocationUrlRoots[game];
       gameLocalizedMapLocations[game] = gameMapLocations[game];
       if (game === gameId) {
+        localizedLocationUrlRoot = locationUrlRoot;
         localizedMapLocations = mapLocations;
         initLocalizedLocations(game);
       }

--- a/play.js
+++ b/play.js
@@ -1353,6 +1353,7 @@ function fetchAndInitLocations(lang, game) {
 }
 
 function fetchAndInitLocalizedMapLocations(lang, game) {
+<<<<<<< HEAD
   return new Promise(resolve => {
     const fileName = lang === 'en' ? 'config' : lang;
     fetchNewest(`locations/${game}/${fileName}.json`)
@@ -1368,41 +1369,48 @@ function fetchAndInitLocalizedMapLocations(lang, game) {
           return null; // Assume map location localizations for this language don't exist
         }
         return response.json();
+=======
+  const fileName = lang === 'en' ? 'config' : lang;
+  return fetchNewest(`locations/${game}/${fileName}.json`)
+    .then(response => {
+      return response.ok ? response.json() : Promise.reject();
+>>>>>>> be6cbea (Always set localized locations to default when fetch fails)
     })
     .then(jsonResponse => {
-        if (!jsonResponse) {
-          resolve();
-          return;
-        }
-        gameLocalizedLocationUrlRoots[game] = jsonResponse.urlRoot;
-        gameLocalizedMapLocations[game] = {};
-        const langMapLocations = jsonResponse.mapLocations;
-        massageMapLocations(langMapLocations, jsonResponse.locationUrlTitles || null);
-        Object.keys(gameMapLocations[game]).forEach(function (mapId) {
-          const mapLocation = langMapLocations[mapId];
-          const defaultMapLocation = gameMapLocations[game][mapId];
-          if (mapLocation) {
-            gameLocalizedMapLocations[game][mapId] = mapLocation;
-            if (Array.isArray(defaultMapLocation) && Array.isArray(mapLocation) && defaultMapLocation.length === mapLocation.length) {
-              for (let l in defaultMapLocation) {
-                if (defaultMapLocation[l].hasOwnProperty('coords'))
-                  mapLocation[l].coords = defaultMapLocation[l].coords;
-              }
+      if (!jsonResponse) {
+        return Promise.reject();
+      }
+      gameLocalizedLocationUrlRoots[game] = jsonResponse.urlRoot;
+      gameLocalizedMapLocations[game] = {};
+      const langMapLocations = jsonResponse.mapLocations;
+      massageMapLocations(langMapLocations, jsonResponse.locationUrlTitles || null);
+      Object.keys(gameMapLocations[game]).forEach(function (mapId) {
+        const mapLocation = langMapLocations[mapId];
+        const defaultMapLocation = gameMapLocations[game][mapId];
+        if (mapLocation) {
+          gameLocalizedMapLocations[game][mapId] = mapLocation;
+          if (Array.isArray(defaultMapLocation) && Array.isArray(mapLocation) && defaultMapLocation.length === mapLocation.length) {
+            for (let l in defaultMapLocation) {
+              if (defaultMapLocation[l].hasOwnProperty('coords'))
+                mapLocation[l].coords = defaultMapLocation[l].coords;
             }
-          } else
-            gameLocalizedMapLocations[game][mapId] = defaultMapLocation;
-        });
-        if (game === gameId) {
-          localizedLocationUrlRoot = gameLocalizedLocationUrlRoots[game];
-          localizedMapLocations = gameLocalizedMapLocations[game];
-        }
-        initLocalizedLocations(game);
-        resolve();
+          }
+        } else
+          gameLocalizedMapLocations[game][mapId] = defaultMapLocation;
+      });
+      if (game === gameId) {
+        localizedLocationUrlRoot = gameLocalizedLocationUrlRoots[game];
+        localizedMapLocations = gameLocalizedMapLocations[game];
+      }
+      initLocalizedLocations(game);
     })
     .catch(_err => { // Assume map location localizations for this language don't exist
-      resolve();
+      gameLocalizedMapLocations[game] = gameMapLocations[game];
+      if (game === gameId) {
+        localizedMapLocations = mapLocations;
+        initLocalizedLocations(game);
+      }
     });
-  });
 }
 
 function initLocalizedLocations(game) {


### PR DESCRIPTION
Currently, localized locations is only set to the default (English) only if the response wasn't OK. This change also includes when the fetch encounters an error and when the response doesn't contain JSON.

This hopefully should fix `gameLocationsMap[eventGameId]` being `undefined` at [`events.js|onUpdateEvents:157`](https://github.com/ynoproject/forest-orb/blob/fa4e03aa9e9e43a202029fc9e9dc8e3e07eed6cd/events.js#L157), as it should ensure that [`play.js|initLocalizedLocations:1353`](https://github.com/ynoproject/forest-orb/blob/fa4e03aa9e9e43a202029fc9e9dc8e3e07eed6cd/play.js#L1353) is always called for languages other than English.