### PR TITLE
iOS Prevent dragging for unselectable class

### DIFF
--- a/play.css
+++ b/play.css
@@ -216,6 +216,7 @@ body {
 }
 
 .unselectable {
+  -webkit-user-drag: none;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   user-select: none;


### PR DESCRIPTION
-webkit-user-drag: none; might be useful for img tags.