### PR TITLE
Erase trailing spaces from UI theme names

### DIFF
--- a/system.js
+++ b/system.js
@@ -219,7 +219,7 @@ const gameLogoBlendModeOverrides = {
 const contrastRatioThreshold = 2.02;
 
 function setSystemName(name) {
-  systemName = name.replace(/'/g, '');
+  systemName = name.replace(/'|\s$/g, '');
   if (playerData) {
     playerData.systemName = name;
     globalPlayerData[playerData.uuid].systemName = name;
@@ -230,7 +230,7 @@ function setSystemName(name) {
 
 // EXTERNAL
 function onUpdateSystemGraphic(name) {
-  if (gameUiThemes.indexOf(name.replace(/'/g, '')) > -1) {
+  if (gameUiThemes.indexOf(name.replace(/'|\s$/g, '')) > -1) {
     setSystemName(name);
     const lastAutoButton = document.querySelector('.uiThemeItem.auto');
     if (lastAutoButton)


### PR DESCRIPTION
Due to the way YNO handles UIs, they should never have trailing spaces as they're invalid in directory names. Extending the regex that replaces `'` s in system names to also match trailing spaces should hypothetically fix this (i.e.- Amillusion's `menulabyrinthe .png` and `System EPACSE .png`).