### PR TITLE
Prevent strikethrough from being seen from inside a spoiler box

### DIFF
--- a/play.css
+++ b/play.css
@@ -1482,6 +1482,7 @@ body.fullBg #background {
 }
 
 .messageContents .spoiler:not(.show) {
+  color: rgb(var(--shadow-color));
   background-color: rgb(var(--shadow-color));
   cursor: pointer;
   -webkit-touch-callout: none;


### PR DESCRIPTION
At least in Firefox, since currently strikethroughs can't even be seen in Chrome at all.

![](https://github.com/ynoproject/forest-orb/assets/73766909/6996b836-f649-4b56-8471-01a915be9f92)

Tested on Firefox (desktop). Works.
Tested on a Chromium-based browser (desktop). No (side) effect.
Not tested on other browsers.