### PR TITLE
Attempt to fix the Tsushin crash for non-English players

### DIFF
--- a/play.js
+++ b/play.js
@@ -1446,8 +1446,11 @@ document.onmousemove = function () {
 
 function setLang(lang, isInit) {
   globalConfig.lang = lang;
-  if (isInit && gameIds.indexOf(gameId) > -1 && gameId !== 'tsushin') // skip language argument for Yume Tsushin to prevent a crash for non-English users
+  fetchNewest(`../data/${gameId}/Language/`).then(response => { // Prevent a crash when the --language argument is used and the game doesn't have a Language folder
+  if (!response.ok && response.status !== 404 && isInit && gameIds.indexOf(gameId) > -1) {
     easyrpgPlayer.language = (gameDefaultLangs.hasOwnProperty(gameId) ? gameDefaultLangs[gameId] !== lang : lang !== 'en') ? lang : 'default';
+    }
+  });
   initLocalization(isInit);
   if (!isInit)
     updateConfig(globalConfig, true);

--- a/play.js
+++ b/play.js
@@ -1552,7 +1552,7 @@ function initLocalization(isInitial) {
           const lang = langOpt.value;
           if (gameDefaultLangs.hasOwnProperty(gameId) ? gameDefaultLangs[gameId] !== lang : lang !== 'en')
             fetchNewest(`../data/${gameId}/Language/${lang}/meta.ini`).then(response => {
-              if (!response.ok && response.status === 404 && gameId !== 'tsushin') { // don't display that the game is not localized for Yume Tsushin since it uses a conlang
+              if (!response.ok && response.status === 404 && gameId !== 'tsushin') { // Don't display that the game is not localized for Yume Tsushin since it uses a conlang
                 langOpt.innerText += '*';
                 langOpt.dataset.noGameLoc = true;
                 if (lang === globalConfig.lang)

--- a/play.js
+++ b/play.js
@@ -1446,7 +1446,7 @@ document.onmousemove = function () {
 
 function setLang(lang, isInit) {
   globalConfig.lang = lang;
-  if (isInit && gameIds.indexOf(gameId) > -1)
+  if (isInit && gameIds.indexOf(gameId) > -1 && gameId !== 'tsushin') // skip language argument for Yume Tsushin to prevent a crash for non-English users
     easyrpgPlayer.language = (gameDefaultLangs.hasOwnProperty(gameId) ? gameDefaultLangs[gameId] !== lang : lang !== 'en') ? lang : 'default';
   initLocalization(isInit);
   if (!isInit)
@@ -1549,7 +1549,7 @@ function initLocalization(isInitial) {
           const lang = langOpt.value;
           if (gameDefaultLangs.hasOwnProperty(gameId) ? gameDefaultLangs[gameId] !== lang : lang !== 'en')
             fetchNewest(`../data/${gameId}/Language/${lang}/meta.ini`).then(response => {
-              if (!response.ok && response.status === 404) {
+              if (!response.ok && response.status === 404 && gameId !== 'tsushin') { // don't display that the game is not localized for Yume Tsushin since it uses a conlang
                 langOpt.innerText += '*';
                 langOpt.dataset.noGameLoc = true;
                 if (lang === globalConfig.lang)


### PR DESCRIPTION
Fix #394 
This pull request adds a detection to prevent the site from using the `--language {LANGUAGE}` argument to start a game in a specified language depending on the language of the site if no Language folder is present, thus fixing an issue where the game would crash if said argument was used and that the Language folder was missing.
This problem causes issues for Yume Tsushin, having no translation, and may cause issues in the future for other games without any translation (OneShot was affected for the April Fools event for instance).
I've also added a check for the language selection of the site to no longer display other languages than English as not having any translation for Yume Tsushin since this game is not planned to be translated due to using a fictive language.
(I tested it a bit and it seems to work but I have no coding knowledge in javascript so this may need to be checked to ensure that nothing breaks)