### PR TITLE
Remove 'add friend' option when targeting accountless users

### DIFF
--- a/init.js
+++ b/init.js
@@ -334,7 +334,7 @@ function addPlayerContextMenu(target, player, uuid, messageType) {
   if (messageType)
     tooltipHtml += `<a href="javascript:void(0);" class="pingPlayerAction playerAction">${getMassagedLabel(localizedMessages.context.ping.label, true).replace('{PLAYER}', playerName)}</a>`;
 
-  if (loginToken) {
+  if (loginToken && player.account) {
     if (tooltipHtml)
       tooltipHtml += '<br>';
     tooltipHtml += `<a href="javascript:void(0);" class="addPlayerFriendAction playerAction">${getMassagedLabel(localizedMessages.context.addFriend.label, true).replace('{PLAYER}', playerName)}</a>


### PR DESCRIPTION
Since they can't accept the requests without an account