### PR TITLE
Badge menu changes

### DIFF
--- a/badges.js
+++ b/badges.js
@@ -218,7 +218,7 @@ function initBadgeControls() {
       }
 
       
-      const nullBadge = getBadgeItem({ badgeId: 'null', game: null }, true, true, true, true);
+      const nullBadge = getBadgeItem({ badgeId: 'null', game: null }, false, true, true, true);
       if ('null' === (playerData?.badge || 'null'))
         nullBadge.children[0].classList.add('selected');
       if (!nullBadge.classList.contains('disabled')) {
@@ -239,6 +239,14 @@ function initBadgeControls() {
 
       function updateBadges(game, group) {
         const items = games[game]?.[group] || [];
+        if (game !== 'ynoproject') {
+          const systemName = getDefaultUiTheme(game).replace(spacePattern, '_');
+          applyThemeStyles(nullBadge, systemName, game);
+        } else {
+          for (const cls of nullBadge.classList)   
+            if (cls.startsWith('theme_'))
+              nullBadge.classList.remove(cls);
+        }
         badgeModalContent.replaceChildren(nullBadge, ...items);
         badgeTabGame = game;
         badgeTabGroup = group;
@@ -266,6 +274,9 @@ function initBadgeControls() {
 
           window.requestAnimationFrame(() => {
             badgeModalContent.replaceChildren(nullBadge);
+            for (const cls of nullBadge.classList)   
+              if (cls.startsWith('theme_'))
+                nullBadge.classList.remove(cls);
             for (const game in games)
               for (const category in games[game])
                 badgeModalContent.append(...games[game][category]);
@@ -355,6 +366,17 @@ function initBadgeControls() {
               window.requestAnimationFrame(() => {
                 badgeCategoryTabs.querySelector('.active')?.classList.remove('active');
                 subTab.classList.add('active');
+
+                const game = tab.dataset.game;
+                if (game !== 'ynoproject') {
+                  const systemName = getDefaultUiTheme(game).replace(spacePattern, '_');
+                  applyThemeStyles(nullBadge, systemName, game);
+                } else {
+                  for (const cls of nullBadge.classList)   
+                    if (cls.startsWith('theme_'))
+                      nullBadge.classList.remove(cls);
+                }
+                
                 badgeModalContent.replaceChildren(nullBadge);
                 for (const group in games[game])
                   badgeModalContent.append(...games[game][group]);

--- a/badges.js
+++ b/badges.js
@@ -217,9 +217,29 @@ function initBadgeControls() {
         games[badge.game][badge.group].push(item);
       }
 
+      
+      const nullBadge = getBadgeItem({ badgeId: 'null', game: null }, true, true, true, true);
+      if ('null' === (playerData?.badge || 'null'))
+        nullBadge.children[0].classList.add('selected');
+      if (!nullBadge.classList.contains('disabled')) {
+        nullBadge.onclick = slotRow && slotCol
+          ? () => updatePlayerBadgeSlot('null', slotRow, slotCol, () => {
+            updateBadgeSlots(() => {
+              initAccountSettingsModal();
+              initBadgeGalleryModal();
+              closeModal()
+            });
+          })
+          : () => updatePlayerBadge('null', () => {
+            initAccountSettingsModal();
+            closeModal();
+          });
+      }
+
+
       function updateBadges(game, group) {
         const items = games[game]?.[group] || [];
-        badgeModalContent.replaceChildren(...items);
+        badgeModalContent.replaceChildren(nullBadge, ...items);
         badgeTabGame = game;
         badgeTabGroup = group;
       }
@@ -245,7 +265,7 @@ function initBadgeControls() {
           badgeCategoryTabs.replaceChildren();
 
           window.requestAnimationFrame(() => {
-            badgeModalContent.replaceChildren();
+            badgeModalContent.replaceChildren(nullBadge);
             for (const game in games)
               for (const category in games[game])
                 badgeModalContent.append(...games[game][category]);
@@ -335,7 +355,7 @@ function initBadgeControls() {
               window.requestAnimationFrame(() => {
                 badgeCategoryTabs.querySelector('.active')?.classList.remove('active');
                 subTab.classList.add('active');
-                badgeModalContent.replaceChildren();
+                badgeModalContent.replaceChildren(nullBadge);
                 for (const group in games[game])
                   badgeModalContent.append(...games[game][group]);
                 badgeTabGame = game;

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "شارات",
+        "allCategory": "جميع",
         "manageBadgeGallery": "إدارة معرض الشارات",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "تنبيه {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "!لقد حصلت على شارة جديدة"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Your screenshot has been taken."
       },
       "saveSync": {
@@ -817,7 +818,7 @@
         "badgeCount": {
           "label": "شارات",
           "valueLabel": "من الشارات #",
-          "value": "{NUMBER}" 
+          "value": "{NUMBER}"
         },
         "bp": {
           "label": "(نقات الشارات)",

--- a/lang/de.json
+++ b/lang/de.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Badges",
+        "allCategory": "All",
         "manageBadgeGallery": "Manage Badge Gallery",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Mention {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "You have unlocked a new badge!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Your screenshot has been taken."
       },
       "saveSync": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Badges",
+        "allCategory": "All",
         "manageBadgeGallery": "Manage Badge Gallery",
         "fields": {
           "unlockStatus": {
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "You have unlocked a new badge!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Your screenshot has been taken."
       },
       "saveSync": {

--- a/lang/es.json
+++ b/lang/es.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Medallas",
+        "allCategory": "Todos",
         "manageBadgeGallery": "Galería de Medallas",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Mention {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "¡Has desbloqueado una nueva medalla!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Your screenshot has been taken."
       },
       "saveSync": {
@@ -948,4 +949,4 @@
       }
     }
   }
-}   
+}

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Badges",
+        "allCategory": "Tous",
         "manageBadgeGallery": "Gérer la galerie des badges",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Mentionner {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "Vous avez obtenu un nouveau badge !"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Votre capture d'écran a été prise."
       },
       "saveSync": {

--- a/lang/it.json
+++ b/lang/it.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Medaglie",
+        "allCategory": "Tutti",
         "manageBadgeGallery": "Vetrina Medaglie",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Mention {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "Hai sbloccato una nuova medaglia!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Your screenshot has been taken."
       },
       "saveSync": {
@@ -948,4 +949,4 @@
       }
     }
   }
-}   
+}

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "バッジ",
+        "allCategory": "全",
         "manageBadgeGallery": "バッジギャラリー管理",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME}（{WEEKDAY}）"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "{PLAYER}にメンション"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "バッジを獲得しました！"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "スクリーンショットが撮影されました。"
       },
       "saveSync": {

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "배지",
+        "allCategory": "전체",
         "manageBadgeGallery": "배지 갤러리 편집",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "멘션 {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "새로운 배지를 해금하였습니다!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "스크린샷이 촬영되었습니다"
       },
       "saveSync": {

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Odznaki",
+        "allCategory": "Wszystkie",
         "manageBadgeGallery": "Zarządzaj galerią odznak",
         "fields": {
           "unlockStatus": {

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Emblemas",
+        "allCategory": "Todos",
         "manageBadgeGallery": "Gerenciar Galeria de Emblemas",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Menciona o {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "Você desbloqueou um novo emblema!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Sua captura de tela foi tirada."
       },
       "saveSync": {

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Insigne",
+        "allCategory": "Toate",
         "manageBadgeGallery": "Gestionare Galerie de Insigne",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Mention {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "Ai deblocat o nouă insignă!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Your screenshot has been taken."
       },
       "saveSync": {

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Значки",
+        "allCategory": "Все",
         "manageBadgeGallery": "Изменить галерею значков",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Упомянуть {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "Значок разблокирован!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Снимок игрового экрана успешно сделан."
       },
       "saveSync": {

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Rozetler",
+        "allCategory": "Hepsi",
         "manageBadgeGallery": "Rozet Galerisini Yönet",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Mention {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "Yeni bir başarım açtın!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Your screenshot has been taken."
       },
       "saveSync": {

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -113,7 +113,7 @@
               "slim": "Phông nhỏ"
             }
           },
-	  "saveReminder": "Save Reminder Frequency",
+          "saveReminder": "Save Reminder Frequency",
           "soundVolume": "Âm lượng Âm thanh",
           "musicVolume": "Âm lượng Âm nhạc",
           "togglePlayerSounds": "Âm thanh người chơi",
@@ -125,7 +125,7 @@
             "label": "Chế độ Đắm chìm",
             "helpText": "Ẩn số người chơi, hộp chat chung và map để đem đến trải nghiệm đắm chìm"
           },
-	  "timeTrialinfo": {
+          "timeTrialinfo": {
             "label": "Time Trial",
             "helpText": "To enable Time Trial mode, hold Shift + -> after starting a new game before anything appears on-screen."
           },
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "Huy Hiệu",
+        "allCategory": "Tất cả",
         "manageBadgeGallery": "Quản lý Kho Huy hiệu",
         "fields": {
           "unlockStatus": {
@@ -513,20 +514,20 @@
         }
       }
     },
-	  "location": {	
-      "template": "{LOCATION}",	
+    "location": {
+      "template": "{LOCATION}",
       "queryingLocation": "Đang tìm địa điểm...",
       "unknownLocation": "Không rõ Địa điểm",
-      "2kki": {	
-        "template": "{LOCATION}"	
+      "2kki": {
+        "template": "{LOCATION}"
       },
       "playing": "Playing {GAME}"
-    },	
-    "locationDisplay": {	
-      "template": "{LOCATION}",	
-      "2kki": {	
-        "template": "{LOCATION}"	
-      }	
+    },
+    "locationDisplay": {
+      "template": "{LOCATION}",
+      "2kki": {
+        "template": "{LOCATION}"
+      }
     },
     "playersOnline": {
       "singular": "{COUNT} Người chơi Online",
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "{TIME} ({WEEKDAY})"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "Gắn thẻ {PLAYER}"
       },
@@ -749,7 +750,7 @@
       "badges": {
         "badgeUnlocked": "Bạn đã mở khóa huy hiệu mới!"
       },
-     "screenshots": {
+      "screenshots": {
         "screenshotTaken": "Đã chụp ảnh màn hình."
       },
       "saveSync": {

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -314,6 +314,7 @@
       },
       "badges": {
         "title": "徽章",
+        "allCategory": "全部",
         "manageBadgeGallery": "管理徽章展柜",
         "fields": {
           "unlockStatus": {
@@ -555,7 +556,7 @@
       "time": "{TIME}",
       "timeAndWeekday": "({WEEKDAY}) {TIME}"
     },
-     "context": {
+    "context": {
       "ping": {
         "label": "提及 {PLAYER}"
       },

--- a/play.css
+++ b/play.css
@@ -3674,3 +3674,8 @@ form .uiTheme {
 #badgeCategoryTabs:empty {
   display: none;
 }
+
+#badgeCategoryTabs {
+  border-bottom: 4px solid transparent;
+  border-image: var(--border-image-url) 8 repeat;
+}

--- a/play.css
+++ b/play.css
@@ -1334,7 +1334,6 @@ body.fullBg #background {
 }
 
 .subTab.active {
-  pointer-events: none;
   cursor: default;
 }
 
@@ -1368,10 +1367,6 @@ body.fullBg #background {
 
 .subTab.active .subTabBg {
   opacity: 0.25;
-}
-
-.subTabLabel {
-  pointer-events: none;
 }
 
 .notificationCount {


### PR DESCRIPTION
Followup of #455

- Added 'All' tab and subtab, showing badges from all games and from specific games
- 'All' subtab is now the default for games with badge groups subdivision
- Only add tooltips to badges when visible
- Allow tooltips on subtabs on be triggered

Remaining tasks:
- [x] Re-add badge removal item
- [x] Gather feedback on where to put the null badge (or a badge removal button)