### PR TITLE
Add i18n keys for HOZO

### DIFF
--- a/lang/ar.json
+++ b/lang/ar.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Game B)",
         "rby_ex": "Red Blue Yellow (Mini Game B) - EX نسخة",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "فتى الكرتون",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - الوضع الصعب",

--- a/lang/de.json
+++ b/lang/de.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Game B)",
         "rby_ex": "Red Blue Yellow (Mini Game B) - EX Version",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/en.json
+++ b/lang/en.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Game B)",
         "rby_ex": "Red Blue Yellow (Mini Game B) - EX Version",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/es.json
+++ b/lang/es.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Juego B)",
         "rby_ex": "Red Blue Yellow (Mini Juego B) - Versión EX",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -893,6 +893,7 @@
         "rby": "Rouge Bleu Jaune (Mini-jeu B)",
         "rby_ex": "Rouge Bleu Jaune (Mini-jeu B) - Version EX",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/it.json
+++ b/lang/it.json
@@ -893,6 +893,7 @@
         "rby": "Rosso Blu Giallo (Mini Game B)",
         "rby_ex": "Rosso Blu Giallo (Mini Game B) - EX Version",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -893,6 +893,7 @@
         "rby": "ミニゲームB",
         "rby_ex": "ミニゲームB（EXver）",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - ハードモード",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -893,6 +893,7 @@
         "rby": "빨강/파랑/노랑 (미니게임 B)",
         "rby_ex": "빨강/파랑/노랑 (미니게임 B) - EX 버전",
         "fuji_ex": "FUJI EX (후지 EX)",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - 하드 모드",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Game B)",
         "rby_ex": "Red Blue Yellow (Mini Game B) - wersja EX",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Game B)",
         "rby_ex": "Red Blue Yellow (Mini Game B) - EX Version",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Game B)",
         "rby_ex": "Red Blue Yellow (Mini Game B) - Versiunea EX",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Мини-Игра Б)",
         "rby_ex": "Red Blue Yellow (Мини-Игра Б) - Версия EX",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Хардкорный режим",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -893,6 +893,7 @@
         "rby": "Kırmızı Mavi Sarı (Mini Oyun B)",
         "rby_ex": "Kırmızı Mavi Sarı (Mini Oyun B) - EX Versiyonu",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mod",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -893,6 +893,7 @@
         "rby": "Red Blue Yellow (Mini Game B)",
         "rby_ex": "Red Blue Yellow (Mini Game B) - Bản EX",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -893,6 +893,7 @@
         "rby": "红蓝黄 (小游戏 B)",
         "rby_ex": "红蓝黄 (小游戏 B) - EX模式",
         "fuji_ex": "FUJI EX",
+        "hozo": "HOZO",
         "cartoonboy": "Cartoon Boy",
         "ta_be": "TA_BE_",
         "ta_be_hardcore": "TA_BE_ - Hardcore Mode",


### PR DESCRIPTION
PR in preparation for changes to ynoserver that would support leaderboards for the new 2kki minigame, HOZO.