### PR TITLE
Fix performance issues when showing toast

### DIFF
--- a/toast.js
+++ b/toast.js
@@ -225,7 +225,7 @@ function showToastMessage(message, icon, iconFill, systemName, persist) {
     toastContainer.classList.remove('anim');
   }
 
-  const rootStyle = document.documentElement.style;
+  const rootStyle = toastContainer.style;
 
   rootStyle.setProperty('--toast-offset', `-${toast.getBoundingClientRect().height + 8}px`);
   setTimeout(() => {


### PR DESCRIPTION
Setting a CSS variable on the root element is expensive, so we can be prudent here and only set it on the toast container, the only place that uses the relevant variables.