### PR TITLE
Fix preloads breaking the game and some other changes

### DIFF
--- a/init.js
+++ b/init.js
@@ -99,7 +99,6 @@ async function injectScripts() {
           checkShowVersionUpdate().then(() => loadingOverlay.classList.add('loaded'));
           fetchAndUpdatePlayerInfo();
           setInterval(checkLogin, 60000);
-          preloadFilesFromMapId('title');
           setTimeout(() => {
             checkDependenciesModified();
             setInterval(checkDependenciesModified, 300000);


### PR DESCRIPTION
* Fix preloads not working properly on title screen
* Preloading of map files and their translations should now work
* Fix game crashing when it loads a file that contains '%' symbol if preloads are enabled (Panorama used for Hospital, Red Lily Lake, Smiling Trees World)