### PR TITLE
Make spoilered [screenshot]s look better in chat

### DIFF
--- a/play.css
+++ b/play.css
@@ -1533,10 +1533,7 @@ body.fullBg #background {
   border: 1px solid rgb(var(--base-color));
   pointer-events: all;
   cursor: pointer;
-}
-
-.messageContents.notext .spoiler {
-  padding: 5px 0 9px 0;
+  display: inline-block;
 }
 
 .messageContents .spoiler:not(.show) {


### PR DESCRIPTION
before
> ![image](https://github.com/user-attachments/assets/03876895-5f20-4aeb-a600-ffd286ba7b41)

after
> ![image](https://github.com/user-attachments/assets/6d611a4c-17eb-4d0b-89f8-20f5400fc7cd)

also removing the bottom style cuz emojis would look like this (with the display: inline-box)
> ![image](https://github.com/user-attachments/assets/0060d91d-23f6-48f9-87f5-e4b890f5d12a)