### PR TITLE
Fix: prevent subTab label line breaks and adjust font size for Japane…

### DIFF
--- a/play.css
+++ b/play.css
@@ -1400,6 +1400,11 @@ body.fullBg #background {
   display: flex;
 }
 
+html[lang="ja"] .subTab {
+  font-size: 14px;
+  white-space: nowrap;
+}
+
 .subTab, .tabButtons button {
   padding: 2px 2px 0 0;
   pointer-events: all;


### PR DESCRIPTION
### Summary

This PR improves the appearance of tab labels in the Japanese UI by preventing unwanted line breaks and adjusting the font size.

### Details

- Applies `font-size: 14px` and `white-space: nowrap` to `.subTab` elements only when the page language is Japanese (`html[lang="ja"]`).
- This change ensures that tab labels such as "ﾏｯﾌﾟ", "ｸﾞﾛｰﾊﾞﾙ", and "ﾊﾟｰﾃｨｰ" do not wrap onto multiple lines, improving readability and layout consistency.
- The modification is scoped to Japanese only and does not affect other languages or unrelated UI elements.

### Motivation

Previously, Japanese tab labels would sometimes break into two lines due to their length, negatively impacting the UI. This fix addresses that issue in a targeted and non-intrusive way.

![image](https://github.com/user-attachments/assets/b356f343-1687-4c6b-b165-4686b039c8ab)
↓
![image](https://github.com/user-attachments/assets/a9a0c4db-ce88-491f-98b4-f11c35f6b2a6)
