### PR TITLE
Add mention filter for chat history

### DIFF
--- a/index.php
+++ b/index.php
@@ -371,6 +371,11 @@
                       <path d="m9 0a1 1 0 0 0 0 18 1 1 0 0 0 0-18m0 3v6l4 4" /><path d="m-2 16l22-14" />
                     </svg>
                   </button>
+                  <button id="mentionFilterButton" class="iconButton toggleButton offToggleButton unselectable" data-i18n="[title]tooltips.chat.filterMentions">
+                    <svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+                      <path d="M13.5 9a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0Zc0 1.657 1.007 3 2.25 3S18 10.657 18 9a9 9 0 10-2.636 6.364M13.5 9V5.25"/><path d="M13.5 9a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0Zc0 1.657 1.007 3 2.25 3S18 10.657 18 9a9 9 0 10-2.636 6.364M13.5 9V5.25"/>
+                    </svg>
+                  </button>
                   <button id="clearChatButton" class="iconButton unselectable" data-i18n="[title]tooltips.chat.clearChat">
                     <svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15">
                       <path d="m3 18l6-4.5h6q3 0 3-3v-7.5q0-3-3-3h-12q-3 0-3 3v7.5q0 3 3 3h1.5l-1.5 4.5m9.5-14.75l-7 7m0-7l7 7" />

--- a/init.js
+++ b/init.js
@@ -925,6 +925,10 @@ function loadOrInitConfig(configObj, global, configName) {
                     if (value)
                       document.getElementById('messageTimestampsButton').click();
                     break;
+                  case 'filterMentions':
+                    if (value)
+                      document.getElementById('mentionFilterButton').click();
+                    break;
                   case 'trackedLocationId':
                     if (value)
                       document.getElementById('nextLocationContainer').classList.remove('hidden');

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "إظهار / إخفاء مواقع رسائل المحادثة",
         "toggleMessageTimestamps": "إظهار / إخفاء الطوابع الزمنية لرسالة المحادثة",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "مسح تاريخ المحادثة"
       },
       "parties": {

--- a/lang/de.json
+++ b/lang/de.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Nächsten Expeditionsstandort anzeigen/ausblenden",
         "toggleGlobalMessageLocations": "Chatnachrichten Ort anzeigen/ausblenden",
         "toggleMessageTimestamps": "Chatnachrichten Zeitstempel anzeigen/ausblenden",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Chat leeren"
       },
       "parties": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "Show/Hide Chat Message Locations",
         "toggleMessageTimestamps": "Show/Hide Chat Message Timestamps",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Clear Chat"
       },
       "parties": {

--- a/lang/eo.json
+++ b/lang/eo.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "Montri/Kaŝi Lokojn de Babilmesaĝoj",
         "toggleMessageTimestamps": "Montri/Kaŝi Tempindikojn de Babilmesaĝoj",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Forigi Babilejon"
       },
       "parties": {

--- a/lang/es.json
+++ b/lang/es.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "Mostrar/Ocultar Ubicaciones en Mensajes de Chat",
         "toggleMessageTimestamps": "Mostrar/Ocultar Marcas de Tiempo en Mensajes de Chat",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Limpiar Chat"
       },
       "parties": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Montrer/Cacher le Lieu de la prochaine expédition",
         "toggleGlobalMessageLocations": "Montrer/Cacher les Lieux dans les messages de Chat",
         "toggleMessageTimestamps": "Montrer/Cacher l'horodatage des messages de Chat",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Effacer le Chat"
       },
       "parties": {

--- a/lang/id.json
+++ b/lang/id.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "Show/Hide Chat Message Locations",
         "toggleMessageTimestamps": "Show/Hide Chat Message Timestamps",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Clear Chat"
       },
       "parties": {

--- a/lang/it.json
+++ b/lang/it.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "Mostra/Nascondi Luoghi dei Messaggi nella Chat",
         "toggleMessageTimestamps": "Mostra/Nascondi i Timestamp dei Messaggi nella Chat",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Svuota Chat"
       },
       "parties": {

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "次のラリーの場所表示のオン／オフ",
         "toggleGlobalMessageLocations": "チャットの場所表示のオン／オフ",
         "toggleMessageTimestamps": "チャットのタイムスタンプ表示のオン／オフ",
+        "filterMentions": "メンションのみ表示",
         "clearChat": "チャットを消去"
       },
       "parties": {

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "채팅 메시지 장소 보이기/숨기기",
         "toggleMessageTimestamps": "채팅 메시지 타임 스탬프 보이기/숨기기",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "채팅 기록 삭제하기"
       },
       "parties": {

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "Pokaż/ukryj lokalizacje w czacie",
         "toggleMessageTimestamps": "Pokaż/ukryj czas wysłania wiadomości",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Wyczyść czat"
       },
       "parties": {

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Mostrar/Ocultar Proxima Localização da Expedição",
         "toggleGlobalMessageLocations": "Mostrar/Ocultar localizações em Mensagens de Bate-Papo",
         "toggleMessageTimestamps": "Mostrar/Ocultar a Hora em Mensagens de Bate-Papo",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Limpar o Chat"
       },
       "parties": {

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Show/Hide Next Expedition Location",
         "toggleGlobalMessageLocations": "Arată/Ascunde Locația în Mesaje",
         "toggleMessageTimestamps": "Arată/Ascunde Marcajele de Timp în Chat",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Șterge Chat-ul"
       },
       "parties": {

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Показать/Скрыть локацию следующей экспедиции",
         "toggleGlobalMessageLocations": "Переключить отображение Локаций в чате",
         "toggleMessageTimestamps": "Переключить отображение Меток времени у сообщений",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Очистить чат"
       },
       "parties": {

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Sonraki Seyahat Konumunu Göster/Sakla",
         "toggleGlobalMessageLocations": " Sohbet Mesaj Konumlarını Göster/Gizle",
         "toggleMessageTimestamps": "Sohbet Mesaj Zamanlarını Göster/Gizle",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Sohbeti Temizle"
       },
       "parties": {

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "Hiện/Ẩn Địa điểm kế tiếp trong Thám hiểm",
         "toggleGlobalMessageLocations": "Hiện/Ẩn Địa điểm trong Chat",
         "toggleMessageTimestamps": "Hiện/Ẩn Thời điểm gửi tin nhắn",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "Xóa Chat"
       },
       "parties": {

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -592,6 +592,7 @@
         "toggleNextLocation": "显示/隐藏 远征导航",
         "toggleGlobalMessageLocations": "显示/隐藏 聊天信息的发送位置",
         "toggleMessageTimestamps": "显示/隐藏 聊天信息时间戳",
+        "filterMentions": "Show Mentions Only",
         "clearChat": "清空记录"
       },
       "parties": {

--- a/play.css
+++ b/play.css
@@ -1485,6 +1485,10 @@ html[lang="ja"] .subTab {
   display: none;
 }
 
+#chatbox #messages.mentionsOnly .messageContainer:not(.highlight) {
+  display: none;
+}
+
 #chatbox.mapChat .messageContainer.global, #chatbox.mapChat .messageContainer.party, #chatbox.globalChat .messageContainer:not(.global), #chatbox.partyChat .messageContainer:not(.party), #chatbox:not(.mapChat) .messageContainer.map, #chatbox:not(.friendsPlayers) #friendsPlayerList, #chatbox:not(.partyPlayers) #partyPlayerList, #chatbox.friendsPlayers #playerList, #chatbox.partyPlayers #playerList {
   display: none;
 }

--- a/play.js
+++ b/play.js
@@ -110,6 +110,7 @@ let config = {
   playersTabIndex: 0,
   globalMessage: false,
   hideGlobalMessageLocations: false,
+  filterMentions: false,
   trackedLocationId: null
 };
 
@@ -1001,6 +1002,14 @@ document.getElementById('globalMessageLocationsButton').onclick = function () {
   const toggled = this.classList.contains('toggled');
   document.getElementById('messages').classList.toggle('hideLocations', toggled);
   config.hideGlobalMessageLocations = toggled;
+  updateConfig(config);
+};
+
+document.getElementById('mentionFilterButton').onclick = function () {
+  this.classList.toggle('toggled');
+  const toggled = this.classList.contains('toggled');
+  document.getElementById('messages').classList.toggle('mentionsOnly', toggled);
+  config.filterMentions = toggled;
   updateConfig(config);
 };
 


### PR DESCRIPTION
### Summary

This PR introduces a "mention filter" feature for chat history.

### Details

- Adds the ability to filter chat messages and display only those that mention the current user (e.g., messages containing @username).
- The filter can be toggled on or off in the chat UI.
- Improves user experience by making it easier to track important messages directed at the user.

### Motivation

Previously, users could easily miss messages that mentioned them, especially in active chats. This feature allows users to quickly find and review all messages where they were mentioned.
