### PR TITLE
Restore chat scroll position after disabling mentionFilter

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -362,6 +362,13 @@ function scrollChatMessages() {
   });
 }
 
+let savedChatScrollTop = 0;
+
+function saveScrollPosition() {
+  const messages = document.getElementById('messages');
+  savedChatScrollTop = messages.scrollTop;
+}
+
 let gameChatModeIndex = 0;
 
 function addGameChatMessage(messageHtml, messageType, senderUuid) {

--- a/play.js
+++ b/play.js
@@ -1008,9 +1008,16 @@ document.getElementById('globalMessageLocationsButton').onclick = function () {
 document.getElementById('mentionFilterButton').onclick = function () {
   this.classList.toggle('toggled');
   const toggled = this.classList.contains('toggled');
+  const messages = document.getElementById('messages');
+  if (toggled)
+    saveScrollPosition();
   document.getElementById('messages').classList.toggle('mentionsOnly', toggled);
   config.filterMentions = toggled;
   updateConfig(config);
+  if (toggled)
+    messages.scrollTop = messages.scrollHeight;
+  else
+    messages.scrollTop = savedChatScrollTop;
 };
 
 document.getElementById('messageTimestampsButton').onclick = function () {


### PR DESCRIPTION
### Summary
This PR implements a feature that restores the previous scroll position of the chat when the mention filter is disabled. This improves the user experience by allowing users to return to their original place in the chat after viewing only @mentions.
