### PR TITLE
Fix: untranslated text in the Locations menu

### DIFF
--- a/index.php
+++ b/index.php
@@ -1349,7 +1349,7 @@
                   <option value="oldest" data-i18n="[html]modal.locations.fields.sortOrder.values.oldest">Oldest</option>
                   <option value="shallowest" data-i18n="[html]modal.locations.fields.sortOrder.values.shallowest">Shallowest</option>
                   <option value="deepest" data-i18n="[html]modal.locations.fields.sortOrder.values.deepest">Deepest</option>
-                  <option value="alpha" data-i18n="[html]modal.locations.fields.sortOrder.values.alphabetical">Alphabetical</option>
+                  <option value="alpha" data-i18n="[html]modal.locations.fields.sortOrder.values.alpha">Alphabetical</option>
                   <option value="players" data-i18n="[html]modal.locations.fields.sortOrder.values.players">Player Count</option>
                 </select>
               </div>

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "اماكن غير مكتشفة",
         "complete": "لقد قمت باكتشاف جميع الاماكن المتاحة :)"
+      },
+      "locations": {
+        "title": "المواقع",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -600,7 +622,7 @@
         "disbandParty": "تفكيك الحفلة"
       },
       "events": "الرحلات الاستكشافية",
-      "locations": "Locations",
+      "locations": "المواقع",
       "communityScreenshots": "لقطات الشاشة للجميع",
       "rankings": "المراتب",
       "schedules": "Events",
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/de.json
+++ b/lang/de.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Unentdeckte Orte",
         "complete": "Du hast jeden verfügbaren Standort gefunden! Gut gemacht!"
+      },
+      "locations": {
+        "title": "Orte",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Ort vermerken",
           "off": "Ort vergessen"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "Alle",
-          "visited": "Besucht",
-          "unvisited": "Unbesucht"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Neuste",
-          "oldest": "Älteste",
-          "shallowest": "Flachste",
-          "deepest": "Tiefste",
-          "alpha": "Alphabetisch",
-          "players": "Spieleranzahl"
         }
       }
     },

--- a/lang/en.json
+++ b/lang/en.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Undiscovered Locations",
         "complete": "You've discovered every available location! Congrats!!"
+      },
+      "locations": {
+        "title": "Locations",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {

--- a/lang/eo.json
+++ b/lang/eo.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Nemalkovritaj Lokoj",
         "complete": "Vi malkovris ĉiujn disponeblajn lokojn! Gratulon!!"
+      },
+      "locations": {
+        "title": "Lokoj",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -600,7 +622,7 @@
         "disbandParty": "Disigi Grupon"
       },
       "events": "Ekspedicioj",
-      "locations": "Locations",
+      "locations": "Lokoj",
       "communityScreenshots": "Komunumaj Ekrankopioj",
       "rankings": "Rangolisto",
       "schedules": "Events",
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/es.json
+++ b/lang/es.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Undiscovered Locations",
         "complete": "You've discovered every available location! Congrats!!"
+      },
+      "locations": {
+        "title": "Ubicaciones",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -600,7 +622,7 @@
         "disbandParty": "Eliminar Equipo"
       },
       "events": "Expediciones",
-      "locations": "Locations",
+      "locations": "Ubicaciones",
       "communityScreenshots": "Community Screenshots",
       "rankings": "Clasificaciones",
       "schedules": "Events",
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Lieux non découverts",
         "complete": "Vous avez découvert tous les lieux disponibles ! Félicitations !!"
+      },
+      "locations": {
+        "title": "Lieux",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "Tous",
+              "visited": "Visités",
+              "unvisited": "Non visités"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Plus Récent",
+              "oldest": "Plus Vieux",
+              "shallowest": "Moins profond",
+              "deepest": "Plus profond",
+              "alpha": "Alphabétique",
+              "players": "Nombre de Joueurs"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Suivre le lieu",
           "off": "Arrêter de suivre le lieu"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "Tous",
-          "visited": "Visités",
-          "unvisited": "Non visités"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Plus Récent",
-          "oldest": "Plus Vieux",
-          "shallowest": "Moins profond",
-          "deepest": "Plus profond",
-          "alpha": "Alphabétique",
-          "players": "Nombre de Joueurs"
         }
       }
     },

--- a/lang/id.json
+++ b/lang/id.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Undiscovered Locations",
         "complete": "You've discovered every available location! Congrats!!"
+      },
+      "locations": {
+        "title": "Locations",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/it.json
+++ b/lang/it.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Undiscovered Locations",
         "complete": "You've discovered every available location! Congrats!!"
+      },
+      "locations": {
+        "title": "Luoghi",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -600,7 +622,7 @@
         "disbandParty": "Elimina Gruppo"
       },
       "events": "Spedizioni",
-      "locations": "Locations",
+      "locations": "Luoghi",
       "communityScreenshots": "Community Screenshots",
       "rankings": "Classifiche",
       "schedules": "Events",
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "未発見の場所",
         "complete": "あなたは到達可能なすべての場所を発見しました！おめでとう！！"
+      },
+      "locations": {
+        "title": "場所一覧",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "全て",
+              "visited": "到達済み",
+              "unvisited": "未到達"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "新しい順",
+              "oldest": "古い順",
+              "shallowest": "浅い順",
+              "deepest": "深い順",
+              "alpha": "アルファベット順",
+              "players": "プレイヤー数順"
+            }
+          }
+        }
       }
     },
     "tooltips": {

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "미발견 장소",
         "complete": "축하합니다!! 방문할 수 있는 모든 장소를 발견하셨습니다!"
+      },
+      "locations": {
+        "title": "장소 찾기",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -600,7 +622,7 @@
         "disbandParty": "파티 해산"
       },
       "events": "탐험",
-      "locations": "Locations",
+      "locations": "장소 찾기",
       "communityScreenshots": "커뮤니티 스크린샷",
       "rankings": "랭킹",
       "schedules": "Events",
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Nieodkryte lokalizacje",
         "complete": "Odkryto wszystkie lokalizacje! Gratulacje!"
+      },
+      "locations": {
+        "title": "Miejsca",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -600,7 +622,7 @@
         "disbandParty": "Usuń grupę"
       },
       "events": "Ekspedycje",
-      "locations": "Locations",
+      "locations": "Miejsca",
       "communityScreenshots": "Zrzuty ekranu społeczności",
       "rankings": "Rankingi",
       "schedules": "Events",
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Locais ainda Não Descobertos",
         "complete": "Você descobriu todos os locais disponíveis! Parabéns!!!"
+      },
+      "locations": {
+        "title": "Localizações",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "Tudo",
+              "visited": "Visitados",
+              "unvisited": "Não Visitados"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Mais Recente",
+              "oldest": "Mais Antigo",
+              "shallowest": "Mais Raso",
+              "deepest": "Mais Profundo",
+              "alpha": "Ordem Alfabética",
+              "players": "Número de Jogadores"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Rastrear localização",
           "off": "Parar de Rastrear localização"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "Tudo",
-          "visited": "Visitados",
-          "unvisited": "Não Visitados"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Mais Recente",
-          "oldest": "Mais Antigo",
-          "shallowest": "Mais Raso",
-          "deepest": "Mais Profundo",
-          "alpha": "Ordem Alfabética",
-          "players": "Número de Jogadores"
         }
       }
     },

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Undiscovered Locations",
         "complete": "You've discovered every available location! Congrats!!"
+      },
+      "locations": {
+        "title": "Locații",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "All",
+              "visited": "Visited",
+              "unvisited": "Unvisited"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Newest",
+              "oldest": "Oldest",
+              "shallowest": "Shallowest",
+              "deepest": "Deepest",
+              "alpha": "Alphabetical",
+              "players": "Player Count"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -600,7 +622,7 @@
         "disbandParty": "Desființează Grupul"
       },
       "events": "Expediții",
-      "locations": "Locations",
+      "locations": "Locații",
       "communityScreenshots": "Community Screenshots",
       "rankings": "Ranguri",
       "schedules": "Events",
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Track Location",
           "off": "Untrack Location"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "All",
-          "visited": "Visited",
-          "unvisited": "Unvisited"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Newest",
-          "oldest": "Oldest",
-          "shallowest": "Shallowest",
-          "deepest": "Deepest",
-          "alpha": "Alphabetical",
-          "players": "Player Count"
         }
       }
     },

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Неисследованная локация",
         "complete": "Вы исследовали все доступные локации! Поздравляем!!!"
+      },
+      "locations": {
+        "title": "Локации",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "Все",
+              "visited": "Посещённые",
+              "unvisited": "Не посещённые"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Новейшие",
+              "oldest": "Старейшие",
+              "shallowest": "Поверхностные",
+              "deepest": "Глубочайшие",
+              "alpha": "По алфавиту",
+              "players": "Кол-во игроков"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Отслеживать",
           "off": "Не отслеживать"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "Все",
-          "visited": "Посещённые",
-          "unvisited": "Не посещённые"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Новейшие",
-          "oldest": "Старейшие",
-          "shallowest": "Поверхностные",
-          "deepest": "Глубочайшие",
-          "alpha": "По алфавиту",
-          "players": "Кол-во игроков"
         }
       }
     },

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Keşfedilmeyen Konumlar",
         "complete": "Mevcut her konumu keşfettiniz! Tebrikler!!"
+      },
+      "locations": {
+        "title": "Konumlar",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "Hepsi",
+              "visited": "Ziyaret Edilmiş",
+              "unvisited": "Ziyaret Edilmemiş"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "En Yeni",
+              "oldest": "En Eski",
+              "shallowest": "En Sığ",
+              "deepest": "En Derin",
+              "alpha": "Alfabetik",
+              "players": "Oyuncu Sayısı"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Lokasyonunu Takip Et",
           "off": "Lokasyonun Takibi Bırak"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "Hepsi",
-          "visited": "Ziyaret Edilmiş",
-          "unvisited": "Ziyaret Edilmemiş"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "En Yeni",
-          "oldest": "En Eski",
-          "shallowest": "En Sığ",
-          "deepest": "En Derin",
-          "alpha": "Alfabetik",
-          "players": "Oyuncu Sayısı"
         }
       }
     },

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "Địa điểm chưa khám phá",
         "complete": "Bạn đã khám phá hết tất cả địa điểm! Chúc mừng!!"
+      },
+      "locations": {
+        "title": "Địa Điểm",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "Tất cả",
+              "visited": "Đã đến",
+              "unvisited": "Chưa đến"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "Mới nhất",
+              "oldest": "Cũ nhất",
+              "shallowest": "Nông nhất",
+              "deepest": "Sâu nhất",
+              "alpha": "Thứ tự bảng chữ cái",
+              "players": "Số người chơi"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "Chỉ đường",
           "off": "Ngưng chỉ đường"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "Tất cả",
-          "visited": "Đã đến",
-          "unvisited": "Chưa đến"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "Mới nhất",
-          "oldest": "Cũ nhất",
-          "shallowest": "Nông nhất",
-          "deepest": "Sâu nhất",
-          "alpha": "Thứ tự bảng chữ cái",
-          "players": "Số người chơi"
         }
       }
     },

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -574,6 +574,28 @@
       "explorerUndiscoveredLocations": {
         "title": "未探索地域",
         "complete": "您已探索完所有可到达的地域！恭喜！"
+      },
+      "locations": {
+        "title": "地点列表",
+        "fields": {
+          "visited": {
+            "values": {
+              "all": "全部",
+              "visited": "已造访",
+              "unvisited": "未造访"
+            }
+          },
+          "sortOrder": {
+            "values": {
+              "newest": "最新",
+              "oldest": "最旧",
+              "shallowest": "最浅",
+              "deepest": "最深",
+              "alpha": "字母顺序",
+              "players": "在线玩家数"
+            }
+          }
+        }
       }
     },
     "tooltips": {
@@ -1087,23 +1109,6 @@
         "tooltip": {
           "on": "导航至此",
           "off": "取消导航"
-        }
-      },
-      "visited": {
-        "values": {
-          "all": "全部",
-          "visited": "已造访",
-          "unvisited": "未造访"
-        }
-      },
-      "sortOrder": {
-        "values": {
-          "newest": "最新",
-          "oldest": "最旧",
-          "shallowest": "最浅",
-          "deepest": "最深",
-          "alpha": "字母顺序",
-          "players": "在线玩家数"
         }
       }
     },


### PR DESCRIPTION
Fixed an issue where some of the UI text in the Locations menu was not being translated properly.

### Changes
- Corrected `data-i18n` attributes for specific labels
- Updated the language JSON to include missing keys

### Related
Fixes #646