### PR TITLE
Fix explorer button to point to explorer.yume.wiki

### DIFF
--- a/2kki.js
+++ b/2kki.js
@@ -396,7 +396,7 @@ function get2kkiExplorerButton(locationName, isMulti) {
   addTooltip(ret, getMassagedLabel(!isMulti ? localizedExplorerLinks.generic : localizedExplorerLinks.multi, true).replace('{LOCATION}', locationName), true, true);
   ret.classList.add('unselectable', 'iconButton');
 
-  const url = `https:///?location=${locationName}&lang=${globalConfig.lang}`;
+  const url = `https://explorer.yume.wiki/?location=${locationName}&lang=${globalConfig.lang}`;
 
   ret.onclick = () => {
     const handle = window.open(url, '_blank');


### PR DESCRIPTION
I think this is the intended behavior? Otherwise it seems to error with both chromium and firefox, and I'm assuming the post params aren't meant for the main site as doing it manually doesn't do anything.