### PR TITLE
Fixed TypeError when localizedMapLocations is uninitialized

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -72,7 +72,7 @@ function chatboxAddMessage(msg, type, player, ignoreNotify, mapId, prevMapId, pr
         if (y !== undefined) msgContainer.dataset.y = y;
         if (prevLocationsStr) msgContainer.dataset.prevLocationsStr = prevLocationsStr;
 
-        if (gameId === "2kki" && (!localizedMapLocations.hasOwnProperty(mapId))) {
+        if (gameId === "2kki" && (!localizedMapLocations || !localizedMapLocations.hasOwnProperty(mapId))) {
           const prevLocations = prevLocationsStr && prevMapId !== "0000" ? decodeURIComponent(window.atob(prevLocationsStr)).split("|").map(l => { return { title: l }; }) : null;
           set2kkiGlobalChatMessageLocation(playerLocation, mapId, prevMapId, prevLocations);
         } else {


### PR DESCRIPTION
### Description
Fixes race condition causing `TypeError` when `localizedMapLocations` is uninitialized during chat history sync

### Changes
- Added null check before calling `hasOwnProperty` on `localizedMapLocations`

Fixes intermittent chat loading failures when sometimes accessing site

Related: Fixes #691 