### PR TITLE
Fixed spammed logout notification toast when already logged out

### DIFF
--- a/play.js
+++ b/play.js
@@ -230,6 +230,7 @@ function fetchAndUpdatePlayerInfo(forLogin) {
     .then(response => response.json())
     .then(jsonResponse => {
       if (jsonResponse.uuid) {
+        const wasLoggedIn = loggedIn;
         loggedIn = !isLogout && jsonResponse.registered;
         setCookie(loggedInKey, loggedIn ? 'true' : '');
         const fsBadgesButton = document.getElementById('fsBadgesButton');
@@ -273,7 +274,7 @@ function fetchAndUpdatePlayerInfo(forLogin) {
               trySetChatName('');
               updatePlayerFriends();
               updateParty();
-              if (isLogout) {
+              if (isLogout && wasLoggedIn) {
                 showAccountToastMessage('loggedOut', 'leave');
                 document.getElementById('content').classList.remove('loggedIn');
                 onResize();


### PR DESCRIPTION
### Description
Stop spammed logout notification toast when for already-logged-out users

### Changes
- Track previous login state
- Only show logout notification if user was previously logged in
- All logout processing remains unchanged, Just don't send logout notifications

Related: Fixes #682 