### PR TITLE
Fixed expedition updates not fetching in singleplayer mode on reconnect

### DIFF
--- a/events.js
+++ b/events.js
@@ -316,7 +316,7 @@ function onUpdateEvents(events, ignoreLocationCheck) {
       eventsList.appendChild(eventListEntry);
     }
 
-    if (eventType === 'locations' && !ignoreLocationCheck && connStatus === 1)
+    if (eventType === 'locations' && !ignoreLocationCheck && (connStatus === 1 || connStatus === 3 || connStatus === 4))
       checkEventLocations();
   }
 

--- a/play.js
+++ b/play.js
@@ -188,7 +188,7 @@ function onUpdateConnectionStatus(status) {
 
   connStatus = status;
 
-  if (status === 1 || status === 3) {
+  if (status === 1 || status === 3 || status === 4) {
     addOrUpdatePlayerListEntry(null, playerData, false, true);
     updatePlayerFriends();
     updateJoinedParty();
@@ -932,8 +932,8 @@ document.getElementById('enterNameForm').onsubmit = function () {
       sendSessionCommand('hl', [config.singleplayerMode ? 1 : 0 ]);
     }
 
-    if (connStatus == 1 || connStatus == 3)
-      onUpdateConnectionStatus(config.privateMode ? 3 : 1);
+    if (connStatus == 1 || connStatus == 3 || connStatus == 4)
+      onUpdateConnectionStatus(config.privateMode ? (config.singleplayerMode ? 4 : 3) : 1);
 
     easyrpgPlayer.api.sessionReady();
   }


### PR DESCRIPTION
### Description
Expedition location updates were not being fetched when reconnecting in singleplayer (and private) mode

### Changes
- Added status check
- This ensures expeditions and other data (friends, party, location sync) are properly updated when reconnecting in singleplayer mode

Related: Fixes #697 