### PR TITLE
Fixed mobile controls option visibility by aligning CSS media queries with JS

### DIFF
--- a/play.css
+++ b/play.css
@@ -3261,13 +3261,13 @@ form .uiTheme {
   font-size: x-small;
 }
 
-@media (hover: none) { 
+@media (hover: none), (pointer: coarse) {
   .desktopOnly {
     display: none;
   }
 }
 
-@media not (hover: none) { 
+@media (hover: hover) and (pointer: fine) {
   .mobileOnly {
     display: none;
   }


### PR DESCRIPTION
### Description
Align CSS media queries with JavaScript's `hasTouchscreen` detection logic to fix mobile controls option visibility issues

### Changes
- Update `.mobileOnly` media query from `not (hover: none)` to `(hover: hover) and (pointer: fine)`
- Update `.desktopOnly` media query from `(hover: none)` to `(hover: none), (pointer: coarse)`

### Fixes
- Mobile controls option not showing on some mobile devices (Samsung devices with Chromium browsers)
- Mobile controls option incorrectly showing on touchscreen laptops

Reference: https://www.ctrl.blog/entry/css-media-hover-samsung.html

Related: #688 