### PR TITLE
Add null check when accessing font shadow colors

### DIFF
--- a/system.js
+++ b/system.js
@@ -969,8 +969,10 @@ async function getFontColorsImgLoaded(img, themeGameId, uiTheme, fontStyle, call
   const colors = Array(data.length / 4);
   for (let i = 0; i < data.length; i += 4)
     colors[i / 4] = [data[i], data[i + 1], data[i + 2]];
-    
+
   if (typeof tinycolor !== 'undefined') {
+    if (!uiThemeFontShadows[themeGameId])
+      uiThemeFontShadows[themeGameId] = {};
     const shadowRgb = uiThemeFontShadows[themeGameId][uiTheme] || [0, 0, 0];
     const shadowTc = getTinyColor(shadowRgb);
     const shadowLum = shadowTc.getLuminance();


### PR DESCRIPTION
### Descriptions

Added initialization check for `uiThemeFontShadows[themeGameId]` before accessing it in `getFontColorsImgLoaded()` about following error:
`Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'system_Negtive')
`
### Fix

Add null check for `uiThemeFontShadows[themeGameId]` to prevent TypeError when accessing font shadow colors

Related #692