### PR TITLE
default to empty object instead of null

### DIFF
--- a/play.js
+++ b/play.js
@@ -2379,7 +2379,7 @@ function fetchAndInitLocations(lang, game) {
             resolve();
       })
       .catch(err => {
-        gameLocalizedMapLocations[game] = null;
+        gameLocalizedMapLocations[game] = {};
         if (game === gameId) {
           ignoredMapIds = [];
           localizedMapLocations = null;


### PR DESCRIPTION
this fixes a bug where badges fail to load since space funeral has badges but no ynolocations config